### PR TITLE
added attach_entity to content object

### DIFF
--- a/lib/draftjs_html/draftjs/block.rb
+++ b/lib/draftjs_html/draftjs/block.rb
@@ -73,6 +73,10 @@ module DraftjsHtml
       def add_style(name, range)
         inline_styles << ApplicableRange.new(name: name, range: range)
       end
+
+      def add_entity(key, range)
+        entity_ranges << ApplicableRange.new(name: key, range: range)
+      end
     end
   end
 end

--- a/lib/draftjs_html/draftjs/content.rb
+++ b/lib/draftjs_html/draftjs/content.rb
@@ -18,8 +18,23 @@ module DraftjsHtml
         entity_map[key]
       end
 
+      def attach_entity(entity, block, range)
+        new_key = new_entity_key
+        entity_map[new_key] = entity
+        block.add_entity(new_key, range)
+      end
+
       def to_raw
         ToRaw.new.convert(self)
+      end
+
+      private
+
+      def new_entity_key
+        loop do
+          key = SecureRandom.uuid
+          break key unless entity_map.key?(key)
+        end
       end
     end
   end

--- a/spec/draftjs_html/draftjs/content_spec.rb
+++ b/spec/draftjs_html/draftjs/content_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe DraftjsHtml::Draftjs::Content do
+  describe '#attach_entity' do
+    it 'attaches an entity to a blocks range' do
+      block = DraftjsHtml::Draftjs::Block.parse({ 'text' => 'any old text' })
+      content = described_class.new(
+        [block],
+        DraftjsHtml::Draftjs::EntityMap.parse({})
+      )
+      entity = DraftjsHtml::Draftjs::Entity.parse({
+        'type' => 'image',
+        'mutability' => 'immutable',
+        'data' => {
+          'href' => 'https://example.com'
+        }
+      })
+
+      content.attach_entity(entity, block, 0..2)
+
+      expect(content.entity_map.size).to eq 1
+      expect(block.entity_ranges.size).to eq 1
+      expect(content.entity_map.keys.first).to eq block.entity_ranges.first.name
+      expect(block.entity_ranges.first.range).to eq 0..2
+    end
+  end
+end


### PR DESCRIPTION
We found we wanted the ability to attach entities to blocks similar to the way we add styles.