### PR TITLE
ignore content blocks inside list items

### DIFF
--- a/lib/draftjs_html/from_html/depth_stack.rb
+++ b/lib/draftjs_html/from_html/depth_stack.rb
@@ -34,7 +34,14 @@ module DraftjsHtml
 
       def pop(draftjs)
         return if @stack.empty?
-        return if inside_parent?
+        if inside_parent?
+          if inside_list_item? && block_content?
+            @stack[-2].consume(current)
+            @stack.pop
+          end
+
+          return
+        end
 
         if @nodes.last == current.tagname && current.flushable?
           flush_to(draftjs)
@@ -100,6 +107,14 @@ module DraftjsHtml
 
       def inside_parent?
         (FromHtml::LIST_PARENT_ELEMENTS & @nodes).any?
+      end
+
+      def inside_list_item?
+        (FromHtml::LIST_ITEM_ELEMENTS & @nodes).any?
+      end
+
+      def block_content?
+        BLOCK_CONTENT_ELEMENTS.include?(current.tagname)
       end
 
       def current

--- a/lib/draftjs_html/from_html/depth_stack.rb
+++ b/lib/draftjs_html/from_html/depth_stack.rb
@@ -39,8 +39,8 @@ module DraftjsHtml
 
         if @nodes.last == current.tagname && current.flushable?
           flush_to(draftjs)
-        elsif previous
-          previous.consume(current)
+        elsif parent
+          parent.consume(current)
         end
 
         @stack.pop
@@ -100,7 +100,7 @@ module DraftjsHtml
       end
 
       def merge_current_into_parent!
-        previous.consume(current)
+        parent.consume(current)
         @stack.pop
       end
 
@@ -124,7 +124,7 @@ module DraftjsHtml
         @stack.last
       end
 
-      def previous
+      def parent
         @stack[-2]
       end
     end

--- a/lib/draftjs_html/from_html/elements.rb
+++ b/lib/draftjs_html/from_html/elements.rb
@@ -2,6 +2,7 @@ module DraftjsHtml
   class FromHtml < Nokogiri::XML::SAX::Document
     INLINE_STYLE_ELEMENTS = HtmlDefaults::HTML_STYLE_TAGS_TO_STYLE.keys.freeze
     LIST_PARENT_ELEMENTS = %w[ol ul].freeze
+    LIST_ITEM_ELEMENTS = %w[li].freeze
     INLINE_NON_STYLE_ELEMENTS = %w[a abbr cite font img output q samp span table thead tbody td time var].freeze
     BLOCK_CONTENT_ELEMENTS = %w[p dl h1 h2 h3 h4 h5 h6].freeze
     FLUSH_BOUNDARIES = %w[OPENING div ol ul li tr].freeze

--- a/lib/draftjs_html/version.rb
+++ b/lib/draftjs_html/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DraftjsHtml
-  VERSION = "0.34.0"
+  VERSION = "0.35.0"
 end

--- a/spec/draftjs_html/from_html/reciprocal_spec.rb
+++ b/spec/draftjs_html/from_html/reciprocal_spec.rb
@@ -47,4 +47,34 @@ RSpec.describe DraftjsHtml::FromHtml, 'Start->ToHtml->FromHtml == Start' do
       text_block 'TTFN'
     }
   end
+
+  it 'can properly convert Microsoft Outlook nested block content in list items to HTML' do
+    subject = described_class.new(squeeze_whitespace_blocks: true)
+    raw_draftjs = subject.convert(<<~HTML)
+      <div>
+        <ul>
+          <li>item 1
+            <p>hello block content at depth 0</p>
+            <ul>
+                <li>item 1.1</li>
+                <li>
+                    <p>hello block content at depth 1</p>
+                </li>
+            </ul>
+          </li>
+          <li>item 2</li>
+        </ul>
+      </div>
+      <span>TTFN</span>
+    HTML
+    DraftjsHtml.to_html(raw_draftjs, options: {})
+
+    expect(raw_draftjs).to eq_raw_draftjs {
+      typed_block 'unordered-list-item', 'item 1hello block content at depth 0', depth: 0
+      typed_block 'unordered-list-item', 'item 1.1', depth: 1
+      typed_block 'unordered-list-item', 'hello block content at depth 1', depth: 1
+      typed_block 'unordered-list-item', 'item 2', depth: 0
+      text_block 'TTFN'
+    }
+  end
 end

--- a/spec/draftjs_html/from_html_spec.rb
+++ b/spec/draftjs_html/from_html_spec.rb
@@ -99,6 +99,42 @@ RSpec.describe DraftjsHtml::FromHtml do
     }
   end
 
+  it '"ignores" invalid block elements inside list item elements' do
+    raw_draftjs = subject.convert(<<~HTML)
+      <ul>
+        <li>Item 1 <p>a second line about item 1</p></li>
+      </ul>
+    HTML
+
+    expect(raw_draftjs).to eq_raw_draftjs {
+      typed_block 'unordered-list-item', 'Item 1 a second line about item 1', depth: 0
+    }
+  end
+
+  it '"ignores" invalid block elements inside nested list item elements' do
+    raw_draftjs = subject.convert(<<~HTML)
+      <ul>
+        <li>Item 1 
+          <p>a second line about item 1</p>
+          <ul>
+            <li>Item 1.1</li>
+            <li>
+                <p>Item 1.2</p>
+            </li>
+          </ul>
+        </li>
+        <li>Item 2</li>
+      </ul>
+    HTML
+
+    expect(raw_draftjs).to eq_raw_draftjs {
+      typed_block 'unordered-list-item', 'Item 1 a second line about item 1', depth: 0
+      typed_block 'unordered-list-item', 'Item 1.1', depth: 1
+      typed_block 'unordered-list-item', 'Item 1.2', depth: 1
+      typed_block 'unordered-list-item', 'Item 2', depth: 0
+    }
+  end
+
   it 'converts `<b>` tags into a `BOLD` `inlineStyleRange`' do
     raw_draftjs = subject.convert(<<~HTML)
       <p>Winter <b>is</b> coming</p>


### PR DESCRIPTION
we encountered some html, likely originating from Outlook, that when converted to draftjs and back to html resulted in a `TypeError: no implicit conversion of nil into String`. It turns out this was due to the parser creating content blocks inside list items with a `depth` greater than 0, which is [unsupported by draftjs](https://draftjs.org/docs/advanced-topics-nested-lists/#internaldocs-banner).

Here we "ignore"/consume any block content inside list items to more closely match the behavior of the DraftJS editor

Co-authored-by: Dallas Reedy <dreedy@forj.ai> 